### PR TITLE
feat(uninstall): add uninstall command to remove global packages

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,2 +1,3 @@
 pub mod install;
 pub mod use_cmd;
+pub mod uninstall;

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -1,0 +1,33 @@
+use std::fs;
+use std::path::PathBuf;
+use crate::utils::get_global_path;
+
+pub fn uninstall_package(pkg: &str) {
+    // Try to remove all versions installed under ~/.jetpm/lib/pkg
+    let base_path = get_global_path(pkg, ""); // returns ~/.jetpm/lib/pkg/
+    let root_path = base_path.parent().unwrap();
+
+    if !root_path.exists() {
+        println!("Package '{}' is not installed.", pkg);
+        return;
+    }
+
+    match fs::remove_dir_all(root_path) {
+        Ok(_) => {
+            println!("Uninstalled '{}'", pkg);
+        }
+        Err(err) => {
+            eprintln!("Failed to uninstall '{}': {}", pkg, err);
+        }
+    }
+
+    // Also remove node_modules symlink if it exists
+    let link_path = PathBuf::from("node_modules").join(pkg);
+    if link_path.exists() {
+        if let Err(e) = fs::remove_file(&link_path) {
+            eprintln!("Failed to remove symlink: {}", e);
+        } else {
+            println!("Removed link from node_modules/{}", pkg);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,16 @@ mod welcome;
 
 use clap::{Parser, Subcommand};
 use commands::{install::install_package, use_cmd::use_package};
+use commands::uninstall::uninstall_package;
 use welcome::show_welcome;
 
 /// JetPM - Jet-fast global JavaScript package manager
 #[derive(Parser)]
-#[command(name = "jetpm", version, about = "Jet-fast global JavaScript package manager")]
+#[command(
+    name = "jetpm",
+    version,
+    about = "Jet-fast global JavaScript package manager"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
@@ -31,6 +36,9 @@ enum Commands {
         /// Package name (e.g., chalk)
         name: String,
     },
+    Uninstall {
+        name: String,
+    },
 }
 
 fn main() {
@@ -42,6 +50,9 @@ fn main() {
         }
         Some(Commands::Use { name }) => {
             use_package(&name);
+        }
+        Some(Commands::Uninstall { name }) => {
+            uninstall_package(&name);
         }
         None => {
             show_welcome();


### PR DESCRIPTION
- Supports removing all versions of a given package from ~/.jetpm/lib
- Also removes symlink from node_modules/<pkg> if it exists
- Gracefully handles already-uninstalled packages