### PR TITLE
feat(list): add command to show installed global packages and versions

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,0 +1,34 @@
+use std::fs;
+use directories::BaseDirs;
+
+pub fn list_packages() {
+    let base = BaseDirs::new().unwrap();
+    let lib_path = base.home_dir().join(".jetpm/lib");
+
+    if !lib_path.exists() {
+        println!("No packages installed.");
+        return;
+    }
+
+    println!("Installed packages:\n");
+
+    let packages = fs::read_dir(&lib_path).unwrap();
+
+    for pkg_entry in packages {
+        let pkg_entry = pkg_entry.unwrap();
+        let pkg_name = pkg_entry.file_name().into_string().unwrap();
+
+        let versions_path = pkg_entry.path();
+        let mut versions = Vec::new();
+
+        if versions_path.is_dir() {
+            for ver_entry in fs::read_dir(versions_path).unwrap() {
+                let ver_entry = ver_entry.unwrap();
+                let ver_name = ver_entry.file_name().into_string().unwrap();
+                versions.push(ver_name);
+            }
+        }
+
+        println!("- {}: {}", pkg_name, versions.join(", "));
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod install;
 pub mod use_cmd;
 pub mod uninstall;
+pub mod list;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,9 @@ mod utils;
 mod welcome;
 
 use clap::{Parser, Subcommand};
-use commands::{install::install_package, use_cmd::use_package};
+use commands::list::list_packages;
 use commands::uninstall::uninstall_package;
+use commands::{install::install_package, use_cmd::use_package};
 use welcome::show_welcome;
 
 /// JetPM - Jet-fast global JavaScript package manager
@@ -21,21 +22,15 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Install a package from the npm registry
     Install {
-        /// Package name (e.g., react or react@18.2.0)
         name: String,
-
-        /// Install inside local project (jetpm_modules/) instead of globally
         #[arg(short, long)]
         internal: bool,
     },
-
-    /// Use a previously installed global package in the current project
     Use {
-        /// Package name (e.g., chalk)
         name: String,
     },
+    List,
     Uninstall {
         name: String,
     },
@@ -53,6 +48,9 @@ fn main() {
         }
         Some(Commands::Uninstall { name }) => {
             uninstall_package(&name);
+        }
+        Some(Commands::List) => {
+            list_packages();
         }
         None => {
             show_welcome();


### PR DESCRIPTION
- Lists all packages installed under ~/.jetpm/lib
- Displays each package along with installed versions
- Skips empty installs or missing directories gracefully
- Prepares foundation for future internal and lockfile support