### PR TITLE
feat(info): add support for fetching package metadata from npm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,7 +210,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -215,8 +230,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -644,11 +671,13 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "directories",
+ "dirs",
  "flate2",
  "reqwest",
  "serde",
  "serde_json",
  "tar",
+ "ureq",
 ]
 
 [[package]]
@@ -890,7 +919,18 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -899,7 +939,7 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -934,6 +974,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,12 +1007,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1090,6 +1179,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,7 +1263,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1176,6 +1280,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1268,6 +1383,30 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -1401,6 +1540,24 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.1",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1630,6 +1787,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ tar = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 directories = "5.0"
+dirs = "6.0.0"
+ureq = { version = "2.9.6", features = ["json"] }
+

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -1,0 +1,58 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct NpmMetadata {
+    #[serde(rename = "dist-tags")]
+    dist_tags: DistTags,
+    versions: serde_json::Value,
+    description: Option<String>,
+    homepage: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DistTags {
+    latest: String,
+}
+
+pub fn info_command(pkg: &str) {
+    let url = format!("https://registry.npmjs.org/{}", pkg);
+
+    let response = match ureq::get(&url).call() {
+        Ok(res) => res,
+        Err(e) => {
+            eprintln!("Failed to fetch package metadata: {}", e);
+            return;
+        }
+    };
+
+    let json: NpmMetadata = match response.into_json::<NpmMetadata>() {
+        Ok(data) => data,
+        Err(e) => {
+            eprintln!("Error parsing JSON: {}", e);
+            return;
+        }
+    };
+
+    println!("Package: {}", pkg);
+    println!("Latest Version: {}", json.dist_tags.latest);
+
+    let mut versions: Vec<String> = json.versions.as_object()
+        .map(|v| v.keys().cloned().collect())
+        .unwrap_or_default();
+
+    versions.sort();
+    versions.reverse();
+
+    println!("Available Versions:");
+    for v in versions.iter().take(10) {
+        println!("  - {}", v);
+    }
+
+    if let Some(desc) = json.description {
+        println!("Description: {}", desc);
+    }
+
+    if let Some(home) = json.homepage {
+        println!("Homepage: {}", home);
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,3 +2,4 @@ pub mod install;
 pub mod use_cmd;
 pub mod uninstall;
 pub mod list;
+pub mod info;

--- a/src/commands/use_cmd.rs
+++ b/src/commands/use_cmd.rs
@@ -1,46 +1,80 @@
+use crate::utils::get_global_path;
 use std::fs;
 use std::path::PathBuf;
-use crate::utils::get_global_path;
 
-/// Activates (symlinks) the latest installed version of a package into `node_modules`
 pub fn use_package(pkg: &str) {
-    // Find latest version installed under ~/.jetpm/lib/<pkg>/
-    let base_path = get_global_path(pkg, ""); // We'll trim version from here
+    let base_dir = dirs::home_dir().unwrap().join(".jetpm/lib").join(pkg);
 
-    // Get list of versions under ~/.jetpm/lib/pkg/
-    let version_root = base_path.parent().unwrap();
-    let versions = fs::read_dir(version_root).unwrap();
-
-    let mut latest_version: Option<String> = None;
-
-    for entry in versions {
-        let entry = entry.unwrap();
-        if entry.path().is_dir() {
-            let name = entry.file_name().into_string().unwrap();
-            latest_version = Some(name);
-        }
-    }
-
-    if latest_version.is_none() {
-        println!("No installed versions of '{}' found.", pkg);
+    if !base_dir.exists() {
+        println!("Package '{}' is not installed.", pkg);
         return;
     }
 
-    let version = latest_version.unwrap();
-    let real_path = get_global_path(pkg, &version);
-    let node_modules = PathBuf::from("node_modules");
+    let mut latest_version: Option<String> = None;
+    if let Ok(entries) = fs::read_dir(&base_dir) {
+        let mut versions: Vec<String> = entries
+            .filter_map(|e| e.ok())
+            .filter_map(|e| e.file_name().into_string().ok())
+            .collect();
+        versions.sort();
+        latest_version = versions.pop();
+    }
 
+    let Some(version) = latest_version else {
+        println!("No installed versions of '{}' found.", pkg);
+        return;
+    };
+
+    let real_path = get_global_path(pkg, &version);
+    if !real_path.exists() {
+        println!("Package version path not found: {}", real_path.display());
+        return;
+    }
+
+    let node_modules = PathBuf::from("node_modules");
     if !node_modules.exists() {
-        fs::create_dir_all(&node_modules).unwrap();
+        if let Err(e) = fs::create_dir_all(&node_modules) {
+            eprintln!("Failed to create node_modules directory: {}", e);
+            return;
+        }
     }
 
     let link_path = node_modules.join(pkg);
 
-    if link_path.exists() {
-        fs::remove_file(&link_path).ok();
+    if let Ok(meta) = fs::symlink_metadata(&link_path) {
+        let file_type = meta.file_type();
+        let result = if file_type.is_symlink() || file_type.is_file() {
+            fs::remove_file(&link_path)
+        } else if file_type.is_dir() {
+            fs::remove_dir_all(&link_path)
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Unknown file type",
+            ))
+        };
+
+        if let Err(e) = result {
+            eprintln!("Failed to remove existing path: {}", e);
+            return;
+        }
     }
 
-    std::os::unix::fs::symlink(&real_path, &link_path).unwrap();
+    #[cfg(target_family = "unix")]
+    {
+        if let Err(e) = std::os::unix::fs::symlink(&real_path, &link_path) {
+            eprintln!("Failed to create symlink: {}", e);
+            return;
+        }
+    }
 
-    println!("Linked {}@{} → node_modules/{}", pkg, version, pkg);
+    #[cfg(target_family = "windows")]
+    {
+        if let Err(e) = std::os::windows::fs::symlink_dir(&real_path, &link_path) {
+            eprintln!("Failed to create symlink: {}", e);
+            return;
+        }
+    }
+
+    println!("{}@{} linked to node_modules/{}", pkg, version, pkg);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use clap::{Parser, Subcommand};
 use commands::list::list_packages;
 use commands::uninstall::uninstall_package;
 use commands::{install::install_package, use_cmd::use_package};
+use commands::info::info_command;
 use welcome::show_welcome;
 
 /// JetPM - Jet-fast global JavaScript package manager
@@ -34,6 +35,7 @@ enum Commands {
     Uninstall {
         name: String,
     },
+    Info { name: String },
 }
 
 fn main() {
@@ -52,6 +54,7 @@ fn main() {
         Some(Commands::List) => {
             list_packages();
         }
+        Some(Commands::Info { name }) => info_command(&name),
         None => {
             show_welcome();
         }


### PR DESCRIPTION
- Introduced `jetpm info <package>` command
- Fetches metadata from the npm registry using ureq
- Displays latest version, description, homepage, and top 10 available versions
- Enabled JSON parsing with serde + ureq's `json` feature